### PR TITLE
Updated to Apache Jena 2.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,21 +28,6 @@
           <version>2.2.4</version>
       </dependency>
 
-
-      <dependency>
-          <groupId>org.apache.jena</groupId>
-          <artifactId>apache-jena-libs</artifactId>
-          <type>pom</type>
-          <version>2.10.1</version>
-      </dependency>
-
-
-      <dependency>
-          <groupId>com.hp.hpl.jena</groupId>
-          <artifactId>jena</artifactId>
-          <version>2.6.4</version>
-      </dependency>
-
       <dependency>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpasyncclient</artifactId>
@@ -61,7 +46,6 @@
           <version>3.3.2</version>
       </dependency>
 
-
       <dependency>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
@@ -74,13 +58,18 @@
           <version>0.8</version>
       </dependency>
 
-
       <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
           <version>15.0</version>
       </dependency>
 
+      <dependency>
+          <groupId>org.apache.jena</groupId>
+          <artifactId>apache-jena-libs</artifactId>
+          <version>2.12.1</version>
+          <type>pom</type>
+      </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/linkeddatafragments/model/ExtendedTripleIteratorLDF.java
+++ b/src/main/java/org/linkeddatafragments/model/ExtendedTripleIteratorLDF.java
@@ -28,47 +28,38 @@ public class ExtendedTripleIteratorLDF implements ExtendedIterator<Triple> {
         return new ExtendedTripleIteratorLDF(ldfClient, ldf);
     }
 
-    @Override
     public Triple removeNext() {
         return triples.removeNext();
     }
 
-    @Override
     public <X extends Triple> ExtendedIterator<Triple> andThen(Iterator<X> other) {
         throw new UnsupportedOperationException();
     }
 
-    @Override
     public ExtendedIterator<Triple> filterKeep(Filter<Triple> f) {
         return triples.filterKeep(f);
     }
 
-    @Override
     public ExtendedIterator<Triple> filterDrop(Filter<Triple> f) {
         return triples.filterDrop(f);
     }
 
-    @Override
     public <U> ExtendedIterator<U> mapWith(Map1<Triple, U> map1) {
         return triples.mapWith(map1);
     }
 
-    @Override
     public List<Triple> toList() {
         return triples.toList();
     }
 
-    @Override
     public Set<Triple> toSet() {
         return triples.toSet();
     }
 
-    @Override
     public void close() {
         triples.close();
     }
 
-    @Override
     public boolean hasNext() {
         Boolean hasNext = triples.hasNext();
         if(!hasNext) {
@@ -83,7 +74,6 @@ public class ExtendedTripleIteratorLDF implements ExtendedIterator<Triple> {
         return hasNext;
     }
 
-    @Override
     public Triple next() {
         Boolean hasNext = triples.hasNext();
         if(!hasNext) {
@@ -97,7 +87,6 @@ public class ExtendedTripleIteratorLDF implements ExtendedIterator<Triple> {
         return triples.next();
     }
 
-    @Override
     public void remove() {
 
     }

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraphCapabilities.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraphCapabilities.java
@@ -4,22 +4,13 @@ import com.hp.hpl.jena.graph.Capabilities;
 
 public class LinkedDataFragmentGraphCapabilities implements Capabilities
 {
-    @Override
     public boolean sizeAccurate() { return true; }
-    @Override
     public boolean addAllowed() { return addAllowed( false ); }
-    @Override
     public boolean addAllowed( boolean every ) { return every; }
-    @Override
     public boolean deleteAllowed() { return deleteAllowed( false ); }
-    @Override
     public boolean deleteAllowed( boolean every ) { return every; }
-    @Override
     public boolean canBeEmpty() { return false; }
-    @Override
     public boolean iteratorRemoveAllowed() { return false; }
-    @Override
     public boolean findContractSafe() { return true; }
-    @Override
     public boolean handlesLiteralTyping() { return true; }
 }

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentIterator.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentIterator.java
@@ -27,12 +27,10 @@ public class LinkedDataFragmentIterator implements Iterator<LinkedDataFragment> 
         return new LinkedDataFragmentIterator(ldf, c);
     }
 
-    @Override
     public boolean hasNext() {
         return currentFragment.hasNextUrl();
     }
 
-    @Override
     public LinkedDataFragment next() {
         try {
             currentFragment = ldfClient.getFragment("GET", currentFragment.getNextUrl(), this.tripleTemplate);
@@ -42,7 +40,6 @@ public class LinkedDataFragmentIterator implements Iterator<LinkedDataFragment> 
         return currentFragment;
     }
 
-    @Override
     public void remove() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/linkeddatafragments/solver/BindingOne.java
+++ b/src/main/java/org/linkeddatafragments/solver/BindingOne.java
@@ -25,27 +25,22 @@ public class BindingOne implements Binding
         this.value = node;
     }
 
-    @Override
     public int size() { return 1 ; }
 
-    @Override
     public boolean isEmpty() { return false ; }
 
     /** Iterate over all the names of variables.
      */
-    @Override
     public Iterator<Var> vars()
     {
         return Iter.singleton(var) ;
     }
 
-    @Override
     public boolean contains(Var n)
     {
         return var.equals(n) ;
     }
 
-    @Override
     public Node get(Var v)
     {
         if ( v.equals(var) )

--- a/src/main/java/org/linkeddatafragments/solver/LDFStatistics.java
+++ b/src/main/java/org/linkeddatafragments/solver/LDFStatistics.java
@@ -24,7 +24,6 @@ public class LDFStatistics implements GraphStatisticsHandler {
     /* (non-Javadoc)
      * @see com.hp.hpl.jena.graph.GraphStatisticsHandler#getStatistic(com.hp.hpl.jena.graph.Node, com.hp.hpl.jena.graph.Node, com.hp.hpl.jena.graph.Node)
      */
-    @Override
     public long getStatistic(Node subject, Node predicate, Node object) {
         //System.out.println("statistics requested");
         return ldfG.getCount(Triple.createMatch(subject, predicate, object));

--- a/src/main/java/org/linkeddatafragments/solver/LinkedDataFragmentEngine.java
+++ b/src/main/java/org/linkeddatafragments/solver/LinkedDataFragmentEngine.java
@@ -55,24 +55,20 @@ public class LinkedDataFragmentEngine extends QueryEngineMain {
 
     static class LinkedDataFragmentEngineFactory implements QueryEngineFactory {
 
-        @Override
         public boolean accept(Query query, DatasetGraph dataset, Context context) {
             return true;
         }
 
-        @Override
         public Plan create(Query query, DatasetGraph dataset, Binding initial, Context context) {
             LinkedDataFragmentEngine engine = new LinkedDataFragmentEngine(query, dataset, initial, context);
             return engine.getPlan();
         }
 
-        @Override
         public boolean accept(Op op, DatasetGraph dataset, Context context) {
             // Refuse to accept algebra expressions directly.
             return false;
         }
 
-        @Override
         public Plan create(Op op, DatasetGraph dataset, Binding inputBinding, Context context) {
             // Should not be called because accept/Op is false
             throw new ARQInternalErrorException("LDFQueryEngine: factory called directly with an algebra expression");

--- a/src/main/java/org/linkeddatafragments/solver/OpExecutorLDF.java
+++ b/src/main/java/org/linkeddatafragments/solver/OpExecutorLDF.java
@@ -25,7 +25,6 @@ public class OpExecutorLDF extends OpExecutor {
 
     public final static OpExecutorFactory opExecFactoryLDF = new OpExecutorFactory()
     {
-        @Override
         public OpExecutor create(ExecutionContext execCxt)
         {
             return new OpExecutorLDF(execCxt) ;
@@ -170,7 +169,6 @@ public class OpExecutorLDF extends OpExecutor {
     private static OpExecutorFactory plainFactory = new OpExecutorPlainFactoryLDF() ;
     private static class OpExecutorPlainFactoryLDF implements OpExecutorFactory
     {
-        @Override
         public OpExecutor create(ExecutionContext execCxt)
         {
             return new OpExecutorPlainLDF(execCxt) ;

--- a/src/main/java/org/linkeddatafragments/solver/ReorderTransformationLDF.java
+++ b/src/main/java/org/linkeddatafragments/solver/ReorderTransformationLDF.java
@@ -7,7 +7,7 @@ import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.sparql.engine.optimizer.Pattern;
 import com.hp.hpl.jena.sparql.engine.optimizer.StatsMatcher;
 import com.hp.hpl.jena.sparql.engine.optimizer.reorder.PatternTriple;
-import com.hp.hpl.jena.sparql.engine.optimizer.reorder.ReorderTransformationBase;
+import com.hp.hpl.jena.sparql.engine.optimizer.reorder.ReorderTransformationSubstitution;
 import com.hp.hpl.jena.sparql.graph.NodeConst;
 import com.hp.hpl.jena.sparql.sse.Item;
 
@@ -24,7 +24,7 @@ import static com.hp.hpl.jena.sparql.engine.optimizer.reorder.PatternElements.VA
  * @author ldevocht
  *
  */
-public class ReorderTransformationLDF extends ReorderTransformationBase {
+public class ReorderTransformationLDF extends ReorderTransformationSubstitution {
 
     /** Maximum value for a match involving two terms. */
     public final long multiTermMax ;


### PR DESCRIPTION
Seemingly no big issues:
- @Override needed to be removed, Eclipse/Java8 complained about that
- ReorderTransformationBase is renamed to ReorderTransformationSubstitution

The test suite runs without any errors after this patch.
