### PR TITLE
compiler properties in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,104 +1,107 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.linkeddatafragments</groupId>
-  <artifactId>ldf-client</artifactId>
-  <version>0.1-SNAPSHOT</version>
-  <packaging>jar</packaging>
+	<groupId>org.linkeddatafragments</groupId>
+	<artifactId>ldf-client</artifactId>
+	<version>0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
 
-  <name>Linked Data Fragments client</name>
-  <url>http://maven.apache.org</url>
+	<name>Linked Data Fragments client</name>
+	<url>http://maven.apache.org</url>
+	<properties>
+		<jena.version>2.13.0</jena.version>
+		<jdk.version>1.7</jdk.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
+	</properties>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-
-      <dependency>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-          <version>2.2.4</version>
-      </dependency>
-
-
-      <dependency>
-          <groupId>org.apache.jena</groupId>
-          <artifactId>apache-jena-libs</artifactId>
-          <type>pom</type>
-          <version>2.13.0</version>
-      </dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.2.4</version>
+		</dependency>
 
 
-      <dependency>
-          <groupId>com.hp.hpl.jena</groupId>
-          <artifactId>jena</artifactId>
-          <version>2.6.4</version>
-      </dependency>
-
-      <dependency>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpasyncclient</artifactId>
-          <version>4.0</version>
-      </dependency>
-
-      <dependency>
-          <groupId>org.easytesting</groupId>
-          <artifactId>fest-assert</artifactId>
-          <version>1.4</version>
-      </dependency>
-
-      <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-          <version>3.3.2</version>
-      </dependency>
+		<dependency>
+			<groupId>org.apache.jena</groupId>
+			<artifactId>apache-jena-libs</artifactId>
+			<type>pom</type>
+			<version>2.13.0</version>
+		</dependency>
 
 
-      <dependency>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-          <version>2.4</version>
-      </dependency>
+		<dependency>
+			<groupId>com.hp.hpl.jena</groupId>
+			<artifactId>jena</artifactId>
+			<version>2.6.4</version>
+		</dependency>
 
-      <dependency>
-          <groupId>com.github.fge</groupId>
-          <artifactId>uri-template</artifactId>
-          <version>0.8</version>
-      </dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpasyncclient</artifactId>
+			<version>4.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.easytesting</groupId>
+			<artifactId>fest-assert</artifactId>
+			<version>1.4</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.3.2</version>
+		</dependency>
 
 
-      <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-          <version>15.0</version>
-      </dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
 
-  </dependencies>
+		<dependency>
+			<groupId>com.github.fge</groupId>
+			<artifactId>uri-template</artifactId>
+			<version>0.8</version>
+		</dependency>
 
-  <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <finalName>ldf-client</finalName>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.linkeddatafragments.client.QueryResultsWriter</mainClass>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-            </plugin>
-        </plugins>
-  </build>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>15.0</version>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<finalName>ldf-client</finalName>
+					<archive>
+						<manifest>
+							<mainClass>org.linkeddatafragments.client.QueryResultsWriter</mainClass>
+						</manifest>
+					</archive>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,6 @@
 	<name>Linked Data Fragments client</name>
 	<url>http://maven.apache.org</url>
 	<properties>
-		<jena.version>2.13.0</jena.version>
-		<jdk.version>1.7</jdk.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>

--- a/src/main/java/org/linkeddatafragments/client/LinkedDataFragmentsGraphAssembler.java
+++ b/src/main/java/org/linkeddatafragments/client/LinkedDataFragmentsGraphAssembler.java
@@ -4,10 +4,6 @@ package org.linkeddatafragments.client;
  * Created by ldevocht on 4/28/14.
  */
 
-import com.hp.hpl.jena.sparql.util.graph.GraphUtils;
-
-import java.io.IOException;
-
 import org.linkeddatafragments.model.LinkedDataFragmentGraph;
 
 import com.hp.hpl.jena.assembler.Assembler;
@@ -18,6 +14,7 @@ import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
+import com.hp.hpl.jena.sparql.util.graph.GraphUtils;
 
 public class LinkedDataFragmentsGraphAssembler extends AssemblerBase implements Assembler {
 

--- a/src/main/java/org/linkeddatafragments/client/QueryResultsWriter.java
+++ b/src/main/java/org/linkeddatafragments/client/QueryResultsWriter.java
@@ -1,12 +1,5 @@
 package org.linkeddatafragments.client;
 
-import com.google.gson.Gson;
-import com.google.gson.stream.JsonReader;
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.query.*;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -17,9 +10,21 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Iterator;
 
-import com.hp.hpl.jena.shared.PrefixMapping;
 import org.linkeddatafragments.model.LinkedDataFragmentGraph;
 import org.linkeddatafragments.utils.Config;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import com.hp.hpl.jena.graph.Triple;
+import com.hp.hpl.jena.query.Query;
+import com.hp.hpl.jena.query.QueryExecution;
+import com.hp.hpl.jena.query.QueryExecutionFactory;
+import com.hp.hpl.jena.query.QueryFactory;
+import com.hp.hpl.jena.query.ResultSet;
+import com.hp.hpl.jena.query.Syntax;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+import com.hp.hpl.jena.shared.PrefixMapping;
 
 /**
  * A QueryResultsWriter executes a query on a graph and writes its results to a stream.
@@ -59,7 +64,7 @@ public class QueryResultsWriter {
         case Query.QueryTypeDescribe:
             final Iterator<Triple> triples = executor.execConstructTriples();
             while (triples.hasNext())
-                outputStream.println(triples.next().asTriple());
+                outputStream.println(triples.next());
             break;
         default:
             throw new Error("Unsupported query type");

--- a/src/main/java/org/linkeddatafragments/model/ExtendedTripleIteratorLDF.java
+++ b/src/main/java/org/linkeddatafragments/model/ExtendedTripleIteratorLDF.java
@@ -1,16 +1,15 @@
 package org.linkeddatafragments.model;
 
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.util.iterator.ExtendedIterator;
-import com.hp.hpl.jena.util.iterator.Filter;
-import com.hp.hpl.jena.util.iterator.Map1;
-import com.hp.hpl.jena.util.iterator.WrappedIterator;
-
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
 import org.linkeddatafragments.client.LinkedDataFragmentsClient;
+
+import com.hp.hpl.jena.graph.Triple;
+import com.hp.hpl.jena.util.iterator.ExtendedIterator;
+import com.hp.hpl.jena.util.iterator.Filter;
+import com.hp.hpl.jena.util.iterator.Map1;
 
 /**
  * Created by ldevocht on 4/29/14.

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentFactory.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentFactory.java
@@ -1,9 +1,6 @@
 package org.linkeddatafragments.model;
 
-import org.linkeddatafragments.model.LinkedDataFragment;
-
 import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.graph.TripleMatch;
 import com.hp.hpl.jena.util.iterator.ExtendedIterator;
 
 /**
@@ -14,19 +11,19 @@ import com.hp.hpl.jena.util.iterator.ExtendedIterator;
  * To change this template use File | Settings | File Templates.
  */
 public class LinkedDataFragmentFactory {
-    public static LinkedDataFragment create(ExtendedIterator<Triple> triples, Long matchCount, TripleMatch m) {
-        return new LinkedDataFragment(triples, matchCount, m);
+    public static LinkedDataFragment create(final ExtendedIterator<Triple> triples, final Long matchCount, final Triple match) {
+        return new LinkedDataFragment(triples, matchCount, match);
     }
 
-    public static LinkedDataFragment create(ExtendedIterator<Triple> triples, TripleMatch m) {
-        return new LinkedDataFragment(triples, m);
+    public static LinkedDataFragment create(final ExtendedIterator<Triple> triples, final Triple match) {
+        return new LinkedDataFragment(triples, match);
     }
 
-    public static LinkedDataFragment create(TripleMatch m) {
-        return new LinkedDataFragment(m);
+    public static LinkedDataFragment create(final Triple match) {
+        return new LinkedDataFragment(match);
     }
 
-    public static LinkedDataFragment create(TripleMatch m, Long matchCount) {
-        return new LinkedDataFragment(m, matchCount);
+    public static LinkedDataFragment create(final Triple match, final Long matchCount) {
+        return new LinkedDataFragment(match, matchCount);
     }
 }

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraph.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraph.java
@@ -1,7 +1,18 @@
 package org.linkeddatafragments.model;
 
+import org.linkeddatafragments.client.LinkedDataFragmentsClient;
+import org.linkeddatafragments.solver.LDFStatistics;
+import org.linkeddatafragments.solver.LinkedDataFragmentEngine;
+import org.linkeddatafragments.solver.OpExecutorLDF;
+import org.linkeddatafragments.solver.ReorderTransformationLDF;
+
 import com.google.common.primitives.Ints;
-import com.hp.hpl.jena.graph.*;
+import com.hp.hpl.jena.graph.Capabilities;
+import com.hp.hpl.jena.graph.Graph;
+import com.hp.hpl.jena.graph.GraphStatisticsHandler;
+import com.hp.hpl.jena.graph.GraphUtil;
+import com.hp.hpl.jena.graph.Node;
+import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.graph.impl.GraphBase;
 import com.hp.hpl.jena.graph.impl.GraphMatcher;
 import com.hp.hpl.jena.query.ARQ;
@@ -13,12 +24,6 @@ import com.hp.hpl.jena.sparql.engine.optimizer.reorder.ReorderTransformation;
 import com.hp.hpl.jena.util.iterator.ClosableIterator;
 import com.hp.hpl.jena.util.iterator.ExtendedIterator;
 import com.hp.hpl.jena.util.iterator.WrappedIterator;
-
-import org.linkeddatafragments.client.LinkedDataFragmentsClient;
-import org.linkeddatafragments.solver.LDFStatistics;
-import org.linkeddatafragments.solver.LinkedDataFragmentEngine;
-import org.linkeddatafragments.solver.OpExecutorLDF;
-import org.linkeddatafragments.solver.ReorderTransformationLDF;
 
 public class LinkedDataFragmentGraph extends GraphBase {
     protected final LinkedDataFragmentsClient ldfClient;
@@ -64,9 +69,9 @@ public class LinkedDataFragmentGraph extends GraphBase {
     }
 
     @Override
-    protected ExtendedIterator<Triple> graphBaseFind(TripleMatch m) {
+    protected ExtendedIterator<Triple> graphBaseFind(Triple match) {
         try{
-            LinkedDataFragment ldf = ldfClient.getFragment(ldfClient.getBaseFragment(), m);
+            LinkedDataFragment ldf = ldfClient.getFragment(ldfClient.getBaseFragment(), match);
 //            ExtendedIterator<Triple> triples = ldf.getTriples();
 //            Iterator<LinkedDataFragment> ldfIterator = LinkedDataFragmentIterator.create(ldf, ldfClient);
 //            while(ldfIterator.hasNext()) {
@@ -81,10 +86,10 @@ public class LinkedDataFragmentGraph extends GraphBase {
         }
     }
 
-    public Long getCount(TripleMatch m) {
+    public Long getCount(final Triple match) {
         //System.out.println("count requested");
         try{
-            LinkedDataFragment ldf = ldfClient.getFragment(ldfClient.getBaseFragment(), m);
+            LinkedDataFragment ldf = ldfClient.getFragment(ldfClient.getBaseFragment(), match);
             Long count = ldf.getMatchCount();
             //System.out.println(String.format("%s found", count));
             return count;
@@ -128,9 +133,10 @@ public class LinkedDataFragmentGraph extends GraphBase {
      the algorithm (indeed, method) in <code>GraphMatcher</code>.
      */
     @Override
-    public boolean isIsomorphicWith( Graph g )
-    { checkOpen();
-        return g != null && GraphMatcher.equals(ldfClient.getBaseFragment().getGraph(), g); }
+    public boolean isIsomorphicWith( Graph g ) { 
+    	checkOpen();
+        return g != null && GraphMatcher.equals(ldfClient.getBaseFragment().getGraph(), g); 
+    }
 
     /**
      Answer a human-consumable representation of this graph. Not advised for
@@ -140,11 +146,15 @@ public class LinkedDataFragmentGraph extends GraphBase {
     /**
      Utility method: throw a ClosedException if this graph has been closed.
      */
-    protected void checkOpen()
-    { if (closed) throw new ClosedException( "already closed", ldfClient.getBaseFragment().getGraph() ); }
+    protected void checkOpen() { 
+    	if (closed) {
+    		throw new ClosedException( "already closed", ldfClient.getBaseFragment().getGraph() ); 
+    	}
+    }
 
-    @Override public String toString()
-    { return toString( (closed ? "closed " : ""), ldfClient.getBaseFragment().getGraph() ); }
+    @Override public String toString() { 
+    	return toString( (closed ? "closed " : ""), ldfClient.getBaseFragment().getGraph() ); 
+    }
 
     /**
      Answer a human-consumable representation of <code>that</code>. The
@@ -153,15 +163,13 @@ public class LinkedDataFragmentGraph extends GraphBase {
      default implementation will display all the triples exposed by the graph (ie
      including reification triples if it is Standard).
      */
-    public static String toString( String prefix, Graph that )
-    {
+    public static String toString( String prefix, Graph that ) {
         PrefixMapping pm = that.getPrefixMapping();
         StringBuffer b = new StringBuffer( prefix + " {" );
         int count = 0;
         String gap = "";
         ClosableIterator<Triple> it = GraphUtil.findAll(that);
-        while (it.hasNext() && count < TOSTRING_TRIPLE_LIMIT)
-        {
+        while (it.hasNext() && count < TOSTRING_TRIPLE_LIMIT) {
             b.append( gap );
             gap = "; ";
             count += 1;
@@ -172,10 +180,4 @@ public class LinkedDataFragmentGraph extends GraphBase {
         b.append( "}" );
         return b.toString();
     }
-
-    @Override
-    protected ExtendedIterator<Triple> graphBaseFind(Triple triple) {
-        return find(triple);
-    }
-
 }

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentIterator.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentIterator.java
@@ -1,22 +1,24 @@
 package org.linkeddatafragments.model;
 
-import com.hp.hpl.jena.graph.TripleMatch;
-
 import java.util.Iterator;
 
 import org.linkeddatafragments.client.LinkedDataFragmentsClient;
 
+import com.hp.hpl.jena.graph.Triple;
+
 /**
- * Created by ldevocht on 4/25/14.
+ * 
+ * @author ldevocht
+ * @author agazzarini
  */
 public class LinkedDataFragmentIterator implements Iterator<LinkedDataFragment> {
     protected final LinkedDataFragment baseFragment;
-    protected final TripleMatch tripleTemplate;
+    protected final Triple tripleTemplate;
     protected final LinkedDataFragmentsClient ldfClient;
 
     protected LinkedDataFragment currentFragment;
 
-    public LinkedDataFragmentIterator(LinkedDataFragment ldf, LinkedDataFragmentsClient c) {
+    public LinkedDataFragmentIterator(final LinkedDataFragment ldf, final LinkedDataFragmentsClient c) {
         baseFragment = ldf;
         tripleTemplate = ldf.tripleMatch;
         currentFragment = baseFragment;

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentsConstants.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentsConstants.java
@@ -9,17 +9,21 @@ import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
 
 /**
- * Created by ldevocht on 4/29/14.
+ * Shared constants.
+ * 
+ * @author ldevocht
+ * @author agazzarini
  */
 public class LinkedDataFragmentsConstants {
-    public static final TripleMatchFilter HYDRA_VARIABLE = new TripleMatchFilter(new Triple(Node.ANY, NodeFactory.createURI("http://www.w3.org/ns/hydra/core#variable"), Node.ANY));
-    public static final TripleMatchFilter HYDRA_PROPERTY = new TripleMatchFilter(new Triple(Node.ANY, NodeFactory.createURI("http://www.w3.org/ns/hydra/core#property"), Node.ANY));
+	public static final String HYDRA_NAMESPACE = "http://www.w3.org/ns/hydra/core#";
+    public static final TripleMatchFilter HYDRA_VARIABLE = new TripleMatchFilter(new Triple(Node.ANY, NodeFactory.createURI(HYDRA_NAMESPACE + "variable"), Node.ANY));
+    public static final TripleMatchFilter HYDRA_PROPERTY = new TripleMatchFilter(new Triple(Node.ANY, NodeFactory.createURI(HYDRA_NAMESPACE + "property"), Node.ANY));
     public static final Property RDF_TYPE_RESOURCE = ResourceFactory.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
     public static final Resource VOID_DATASET_RESOURCE = ResourceFactory.createResource("http://rdfs.org/ns/void#Dataset");
-    public static final Property HYDRA_NEXTPAGE = ResourceFactory.createProperty("http://www.w3.org/ns/hydra/core#nextPage");
-    public static final Property HYDRA_TOTALITEMS = ResourceFactory.createProperty("http://www.w3.org/ns/hydra/core#totalItems");
-    public static final Property HYDRA_TEMPLATE = ResourceFactory.createProperty("http://www.w3.org/ns/hydra/core#template");
-    public static final Resource HYDRA_PAGEDCOLLECTION = ResourceFactory.createResource("http://www.w3.org/ns/hydra/core#PagedCollection");
+    public static final Property HYDRA_NEXTPAGE = ResourceFactory.createProperty(HYDRA_NAMESPACE + "nextPage");
+    public static final Property HYDRA_TOTALITEMS = ResourceFactory.createProperty(HYDRA_NAMESPACE + "totalItems");
+    public static final Property HYDRA_TEMPLATE = ResourceFactory.createProperty(HYDRA_NAMESPACE + "template");
+    public static final Resource HYDRA_PAGEDCOLLECTION = ResourceFactory.createResource(HYDRA_NAMESPACE + "PagedCollection");
     public static final Property VOID_TRIPLES = ResourceFactory.createProperty("http://rdfs.org/ns/void#triples");
     public static final Resource RDF_SUBJECT = ResourceFactory.createResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#subject");
     public static final Resource RDF_OBJECT = ResourceFactory.createResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#object");

--- a/src/main/java/org/linkeddatafragments/solver/OpExecutorLDF.java
+++ b/src/main/java/org/linkeddatafragments/solver/OpExecutorLDF.java
@@ -100,13 +100,13 @@ public class OpExecutorLDF extends OpExecutor {
     private static QueryIterator optimizeExecuteTriples(LinkedDataFragmentGraph graph,
                                                         QueryIterator input, BasicPattern pattern, ExprList exprs,
                                                         ExecutionContext execCxt) {
-        if ( ! input.hasNext() )
+        if ( ! input.hasNext() ) {
             return input ;
+        }
 
         // -- Input
         // Must pass this iterator into the next stage.
-        if ( pattern.size() >= 2 )
-        {
+        if ( pattern.size() >= 2 ) {
             // Must be 2 or triples to reorder.
             ReorderTransformation transform = graph.getReorderTransform() ;
             if ( transform != null )
@@ -128,8 +128,7 @@ public class OpExecutorLDF extends OpExecutor {
     }
 
     /** Execute without modification of the op - does <b>not</b> apply special graph name translations */
-    private static QueryIterator plainExecute(Op op, QueryIterator input, ExecutionContext execCxt)
-    {
+    private static QueryIterator plainExecute(Op op, QueryIterator input, ExecutionContext execCxt) {
         // -- Execute
         // Switch to a non-reordering executor
         // The Op may be a sequence due to TransformFilterPlacement
@@ -145,19 +144,18 @@ public class OpExecutorLDF extends OpExecutor {
         return QC.execute(op, input, ec2) ;
     }
 
-    private static BasicPattern reorder(BasicPattern pattern, QueryIterPeek peek, ReorderTransformation transform)
-    {
-        if ( transform != null )
-        {
+    private static BasicPattern reorder(BasicPattern pattern, QueryIterPeek peek, ReorderTransformation transform) {
+        if ( transform != null ) {
             // This works by getting one result from the peek iterator,
             // and creating the more gounded BGP. The tranform is used to
             // determine the best order and the transformation is returned. This
             // transform is applied to the unsubstituted pattern (which will be
             // substituted as part of evaluation.
 
-            if ( ! peek.hasNext() )
+            if ( ! peek.hasNext() ) {
                 throw new ARQInternalErrorException("Peek iterator is already empty") ;
-
+            }
+            
             BasicPattern pattern2 = Substitute.substitute(pattern, peek.peek() ) ;
             // Calculate the reordering based on the substituted pattern.
             ReorderProc proc = transform.reorderIndexes(pattern2) ;
@@ -168,28 +166,21 @@ public class OpExecutorLDF extends OpExecutor {
     }
 
     private static OpExecutorFactory plainFactory = new OpExecutorPlainFactoryLDF() ;
-    private static class OpExecutorPlainFactoryLDF implements OpExecutorFactory
-    {
+    private static class OpExecutorPlainFactoryLDF implements OpExecutorFactory {
         @Override
-        public OpExecutor create(ExecutionContext execCxt)
-        {
+        public OpExecutor create(ExecutionContext execCxt) {
             return new OpExecutorPlainLDF(execCxt) ;
         }
     }
 
     /** An op executor that simply executes a BGP or QuadPattern without any reordering */
-    private static class OpExecutorPlainLDF extends OpExecutor
-    {
-
-        @SuppressWarnings("unchecked")
-        public OpExecutorPlainLDF(ExecutionContext execCxt)
-        {
+    private static class OpExecutorPlainLDF extends OpExecutor {
+        public OpExecutorPlainLDF(ExecutionContext execCxt) {
             super(execCxt) ;
         }
 
         @Override
-        public QueryIterator execute(OpBGP opBGP, QueryIterator input)
-        {
+        public QueryIterator execute(OpBGP opBGP, QueryIterator input) {
             return super.execute(opBGP, input) ;
         }
     }

--- a/src/main/java/org/linkeddatafragments/utils/Config.java
+++ b/src/main/java/org/linkeddatafragments/utils/Config.java
@@ -1,9 +1,8 @@
 package org.linkeddatafragments.utils;
 
-import com.google.common.collect.Maps;
-
-import java.util.List;
 import java.util.Map;
+
+import com.google.common.collect.Maps;
 
 /**
  * Created by ldevocht on 4/29/14.

--- a/src/test/java/org/linkeddatafragments/LinkedDataFragmentsClientTest.java
+++ b/src/test/java/org/linkeddatafragments/LinkedDataFragmentsClientTest.java
@@ -1,20 +1,24 @@
 package org.linkeddatafragments;
 
-import com.google.common.base.Stopwatch;
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.query.*;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Iterator;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.linkeddatafragments.model.LinkedDataFragmentGraph;
 import org.linkeddatafragments.util.LDFTestUtils;
 
-import java.util.Iterator;
-import java.util.List;
-
-import static org.fest.assertions.Assertions.assertThat;
+import com.google.common.base.Stopwatch;
+import com.hp.hpl.jena.graph.Triple;
+import com.hp.hpl.jena.query.Query;
+import com.hp.hpl.jena.query.QueryExecution;
+import com.hp.hpl.jena.query.QueryExecutionFactory;
+import com.hp.hpl.jena.query.QueryFactory;
+import com.hp.hpl.jena.query.ResultSet;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
 
 public class LinkedDataFragmentsClientTest {
     protected Model model;
@@ -161,7 +165,7 @@ public class LinkedDataFragmentsClientTest {
                 assertThat(rm.hasNext()).isTrue();
 
                 while(rm.hasNext()) {
-                    System.out.println(rm.next().asTriple().toString());
+                    System.out.println(rm.next().toString());
                 }
 
             } else if(qe.getQuery().getQueryType() == Query.QueryTypeSelect) {

--- a/src/test/java/org/linkeddatafragments/util/LDFTestUtils.java
+++ b/src/test/java/org/linkeddatafragments/util/LDFTestUtils.java
@@ -24,7 +24,7 @@ public class LDFTestUtils {
 
     public static List<String> readFiles(String directoryPath) {
         List<String> fileContents = Lists.newArrayList();
-        Iterator it = FileUtils.iterateFiles(new File(directoryPath), null, false);
+        Iterator<File> it = FileUtils.iterateFiles(new File(directoryPath), null, false);
         while(it.hasNext()){
             File file = ((File) it.next());
             System.out.println(file.getName());


### PR DESCRIPTION
Hi @RubenVerborgh I changed a bit the pom.xml of the project because after importing it, Eclipse complained about a wrong usage of the @Override annotation. 
That is because in Java 5 (the default version picked up, at least by m2e) that annotation was allowed only between, strictly speaking, overriden methods; for instance it wasn't allowed between an interface method and its corresponding implementation (in another class) like org.linkeddatafragments.solver.BindingOne.vars()

Well, briefly: I change the pom.xml including Java 7 as target and source level. Also Java 6 could be good from that perspective but I think it's a bit old.  

AG
