### PR TITLE
Java 8 - Jena 3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <log4j.version>2.5</log4j.version>
   </properties>
 
   <dependencies>
@@ -79,6 +80,23 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
           <version>15.0</version>
+      </dependency>
+
+      <!-- Logging -->
+      <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+          <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+          <version>${log4j.version}</version>
+      </dependency>
+      <dependency> <!-- log4j logging to slf4j -->
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+          <version>${log4j.version}</version>
       </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,15 +33,15 @@
           <groupId>org.apache.jena</groupId>
           <artifactId>apache-jena-libs</artifactId>
           <type>pom</type>
-          <version>2.13.0</version>
+          <version>3.1.0</version>
       </dependency>
 
 
-      <dependency>
+      <!--dependency>
           <groupId>com.hp.hpl.jena</groupId>
           <artifactId>jena</artifactId>
-          <version>2.6.4</version>
-      </dependency>
+          <version>3.1.0</version>
+      </dependency-->
 
       <dependency>
           <groupId>org.apache.httpcomponents</groupId>
@@ -97,6 +97,15 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
+                </configuration>
+            </plugin>
+            <plugin> <!-- set compiler to 8.0 source -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
       <dependency>
           <groupId>com.google.code.gson</groupId>
           <artifactId>gson</artifactId>
-          <version>2.2.4</version>
+          <version>2.7</version>
       </dependency>
 
 
@@ -37,17 +37,10 @@
           <version>3.1.0</version>
       </dependency>
 
-
-      <!--dependency>
-          <groupId>com.hp.hpl.jena</groupId>
-          <artifactId>jena</artifactId>
-          <version>3.1.0</version>
-      </dependency-->
-
       <dependency>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpasyncclient</artifactId>
-          <version>4.0</version>
+          <version>4.1.2</version>
       </dependency>
 
       <dependency>
@@ -59,27 +52,27 @@
       <dependency>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
-          <version>3.3.2</version>
+          <version>3.4</version>
       </dependency>
 
 
       <dependency>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
-          <version>2.4</version>
+          <version>2.5</version>
       </dependency>
 
       <dependency>
           <groupId>com.github.fge</groupId>
           <artifactId>uri-template</artifactId>
-          <version>0.8</version>
+          <version>0.9</version>
       </dependency>
 
 
       <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-          <version>15.0</version>
+          <version>19.0</version>
       </dependency>
 
       <!-- Logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <log4j.version>2.5</log4j.version>
+      <log4j.version>2.6.2</log4j.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/linkeddatafragments/client/LinkedDataFragmentsClient.java
+++ b/src/main/java/org/linkeddatafragments/client/LinkedDataFragmentsClient.java
@@ -3,15 +3,6 @@ package org.linkeddatafragments.client;
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.hp.hpl.jena.graph.Graph;
-import com.hp.hpl.jena.graph.GraphUtil;
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.graph.TripleMatch;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.reasoner.TriplePattern;
-import com.hp.hpl.jena.sparql.graph.GraphFactory;
-import com.hp.hpl.jena.util.iterator.WrappedIterator;
 
 import org.apache.http.Header;
 import org.apache.http.HeaderElement;
@@ -21,6 +12,13 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.GraphUtil;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.reasoner.TriplePattern;
+import org.apache.jena.sparql.graph.GraphFactory;
 import org.linkeddatafragments.model.LinkedDataFragment;
 import org.linkeddatafragments.model.LinkedDataFragmentFactory;
 import org.linkeddatafragments.model.LinkedDataFragmentIterator;
@@ -61,11 +59,11 @@ public class LinkedDataFragmentsClient {
     }
 
 
-    public LinkedDataFragment getFragment(LinkedDataFragment baseFragment, TripleMatch pattern) throws Exception {
+    public LinkedDataFragment getFragment(LinkedDataFragment baseFragment, Triple pattern) throws Exception {
         //Boolean hasVariables;
         //Node s,p,o;
         String method = "GET";
-        TripleMatch tripleTemplate = pattern;
+        Triple tripleTemplate = pattern;
         TriplePattern p = new TriplePattern(pattern);
 
         // TODO: if looking for a specific triple (no variables), we can use shortcuts
@@ -91,7 +89,7 @@ public class LinkedDataFragmentsClient {
     // Triple patternT =
     //        Triple.create(Var.alloc("s"), Var.alloc("p"), Var.alloc("o"));
     // new TriplePattern(patternT);
-    public LinkedDataFragment getFragment(String method, String fragmentUrl, TripleMatch tripleTemplate) throws Exception {
+    public LinkedDataFragment getFragment(String method, String fragmentUrl, Triple tripleTemplate) throws Exception {
 //        String hash = "" + fragmentUrl.hashCode() + tripleTemplate.hashCode();
 //
 //        Optional<LinkedDataFragment> fragmentOptional = Optional.fromNullable(fragments.getIfPresent(hash));
@@ -118,7 +116,7 @@ public class LinkedDataFragmentsClient {
         } else {
             if(response.getStatusLine().getStatusCode() == 200) {
                 Graph g = GraphFactory.createJenaDefaultGraph();
-                g.add(tripleTemplate.asTriple());
+                g.add(tripleTemplate);
                 ldf = LinkedDataFragmentFactory.create(tripleTemplate); // do not send request if pattern was already fetched
             } else {
                 ldf = LinkedDataFragmentFactory.create(tripleTemplate, 0L);

--- a/src/main/java/org/linkeddatafragments/client/LinkedDataFragmentsClient.java
+++ b/src/main/java/org/linkeddatafragments/client/LinkedDataFragmentsClient.java
@@ -125,21 +125,20 @@ public class LinkedDataFragmentsClient {
 //            return fragmentOptional.get();
 //        }
 
-//        Model fragmentTriples = ModelFactory.createDefaultModel();
-//        fragmentTriples.getReader().setProperty("WARN_UNQUALIFIED_RDF_ATTRIBUTE","EM_IGNORE");
-//        fragmentTriples.getReader().setProperty("allowBadURIs","true");
+        Model fragmentTriples = ModelFactory.createDefaultModel();
+        fragmentTriples.getReader().setProperty("WARN_UNQUALIFIED_RDF_ATTRIBUTE","EM_IGNORE");
+        fragmentTriples.getReader().setProperty("allowBadURIs","true");
 
-        HttpResponse response = getLinkedDataFragment("HEAD", fragmentUrl);
+        HttpResponse response = getLinkedDataFragment("GET", fragmentUrl);
         //System.out.println(fragmentUrl);
         //String remoteUrl = baseFragment.getUrlToFragment(tripleTemplate);
         //fragmentTriples.read(remoteUrl,"TURTLE");
         LinkedDataFragment ldf;
         if(method.equals("GET")) {
-//            InputStream in = parseLDFInputStream(response);
-            Dataset dataset = RDFDataMgr.loadDataset(fragmentUrl);
-            Model fragmentTriples = getFragmentTriples(dataset);
-//            fragmentTriples.read(in, null, "TURTLE");
-            //fragmentTriples.write(System.out, "TURTLE");
+            InputStream in = parseLDFInputStream(response);
+//            Dataset dataset = RDFDataMgr.loadDataset(fragmentUrl);
+//            Model fragmentTriples = getFragmentTriples(dataset);
+            fragmentTriples.read(in, null, "TURTLE");
             ldf = LinkedDataFragmentFactory.create(GraphUtil.findAll(fragmentTriples.getGraph()), fragmentTriples.size(), tripleTemplate);
 //        fragments.put(hash, ldf);
         } else {

--- a/src/main/java/org/linkeddatafragments/client/LinkedDataFragmentsGraphAssembler.java
+++ b/src/main/java/org/linkeddatafragments/client/LinkedDataFragmentsGraphAssembler.java
@@ -4,20 +4,17 @@ package org.linkeddatafragments.client;
  * Created by ldevocht on 4/28/14.
  */
 
-import com.hp.hpl.jena.sparql.util.graph.GraphUtils;
-
-import java.io.IOException;
-
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.assembler.Mode;
+import org.apache.jena.assembler.assemblers.AssemblerBase;
+import org.apache.jena.assembler.exceptions.AssemblerException;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.util.graph.GraphUtils;
 import org.linkeddatafragments.model.LinkedDataFragmentGraph;
 
-import com.hp.hpl.jena.assembler.Assembler;
-import com.hp.hpl.jena.assembler.Mode;
-import com.hp.hpl.jena.assembler.assemblers.AssemblerBase;
-import com.hp.hpl.jena.assembler.exceptions.AssemblerException;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.rdf.model.ResourceFactory;
 
 public class LinkedDataFragmentsGraphAssembler extends AssemblerBase implements Assembler {
 

--- a/src/main/java/org/linkeddatafragments/client/QueryResultsWriter.java
+++ b/src/main/java/org/linkeddatafragments/client/QueryResultsWriter.java
@@ -2,10 +2,6 @@ package org.linkeddatafragments.client;
 
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.query.*;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -17,7 +13,11 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Iterator;
 
-import com.hp.hpl.jena.shared.PrefixMapping;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.shared.PrefixMapping;
 import org.linkeddatafragments.model.LinkedDataFragmentGraph;
 import org.linkeddatafragments.utils.Config;
 
@@ -59,7 +59,7 @@ public class QueryResultsWriter {
         case Query.QueryTypeDescribe:
             final Iterator<Triple> triples = executor.execConstructTriples();
             while (triples.hasNext())
-                outputStream.println(triples.next().asTriple());
+                outputStream.println(triples.next());
             break;
         default:
             throw new Error("Unsupported query type");

--- a/src/main/java/org/linkeddatafragments/model/ExtendedTripleIteratorLDF.java
+++ b/src/main/java/org/linkeddatafragments/model/ExtendedTripleIteratorLDF.java
@@ -1,15 +1,16 @@
 package org.linkeddatafragments.model;
 
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.util.iterator.ExtendedIterator;
-import com.hp.hpl.jena.util.iterator.Filter;
-import com.hp.hpl.jena.util.iterator.Map1;
-import com.hp.hpl.jena.util.iterator.WrappedIterator;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
+import org.apache.jena.graph.Triple;
+import org.apache.jena.util.iterator.ExtendedIterator;
+import org.apache.jena.util.iterator.Filter;
+import org.apache.jena.util.iterator.Map1;
 import org.linkeddatafragments.client.LinkedDataFragmentsClient;
 
 /**
@@ -39,18 +40,18 @@ public class ExtendedTripleIteratorLDF implements ExtendedIterator<Triple> {
     }
 
     @Override
-    public ExtendedIterator<Triple> filterKeep(Filter<Triple> f) {
-        return triples.filterKeep(f);
+    public ExtendedIterator<Triple> filterKeep(Predicate<Triple> predicate) {
+        return triples.filterKeep(predicate);
     }
 
     @Override
-    public ExtendedIterator<Triple> filterDrop(Filter<Triple> f) {
-        return triples.filterDrop(f);
+    public ExtendedIterator<Triple> filterDrop(Predicate<Triple> predicate) {
+        return triples.filterDrop(predicate);
     }
 
     @Override
-    public <U> ExtendedIterator<U> mapWith(Map1<Triple, U> map1) {
-        return triples.mapWith(map1);
+    public <U> ExtendedIterator<U> mapWith(Function<Triple, U> function) {
+        return triples.mapWith(function);
     }
 
     @Override

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragment.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragment.java
@@ -86,13 +86,15 @@ public class LinkedDataFragment {
         setTemplate();
         setMatchCount();
         this.triples = GraphUtil.findAll(g)
-                .filterKeep(triple -> triple.matches(tripleMatch))
-                .filterDrop(triple -> triple.matches(new Triple(NodeFactory.createURI(url), Node.ANY, Node.ANY)))
-                .filterDrop(triple -> triple.matches(new Triple(pattern.asNode(), Node.ANY, Node.ANY)))
-                .filterDrop(triple -> triple.matches(LinkedDataFragmentsConstants.HYDRA_VARIABLE))
-                .filterDrop(triple -> triple.matches(LinkedDataFragmentsConstants.HYDRA_PROPERTY));
+                .filterKeep(triple -> tripleMatch.matches(triple))
+                .filterDrop(triple -> new Triple(NodeFactory.createURI(url), Node.ANY, Node.ANY).matches(triple))
+                .filterDrop(triple -> new Triple(pattern.asNode(), Node.ANY, Node.ANY).matches(triple))
+                .filterDrop(triple -> LinkedDataFragmentsConstants.HYDRA_VARIABLE.matches(triple))
+                .filterDrop(triple -> LinkedDataFragmentsConstants.HYDRA_PROPERTY.matches(triple));
+
         if(fragmentNode != null) {
-            this.triples = this.triples.filterDrop(triple -> triple.matches(new Triple(fragmentNode.asNode(), Node.ANY, Node.ANY)));
+            this.triples = this.triples.filterDrop(
+                    triple -> new Triple(fragmentNode.asNode(), Node.ANY, Node.ANY).matches(triple));
         }
     }
 

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentFactory.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentFactory.java
@@ -1,10 +1,8 @@
 package org.linkeddatafragments.model;
 
-import org.linkeddatafragments.model.LinkedDataFragment;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.util.iterator.ExtendedIterator;
 
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.graph.TripleMatch;
-import com.hp.hpl.jena.util.iterator.ExtendedIterator;
 
 /**
  * Created with IntelliJ IDEA.
@@ -14,19 +12,19 @@ import com.hp.hpl.jena.util.iterator.ExtendedIterator;
  * To change this template use File | Settings | File Templates.
  */
 public class LinkedDataFragmentFactory {
-    public static LinkedDataFragment create(ExtendedIterator<Triple> triples, Long matchCount, TripleMatch m) {
+    public static LinkedDataFragment create(ExtendedIterator<Triple> triples, Long matchCount, Triple m) {
         return new LinkedDataFragment(triples, matchCount, m);
     }
 
-    public static LinkedDataFragment create(ExtendedIterator<Triple> triples, TripleMatch m) {
+    public static LinkedDataFragment create(ExtendedIterator<Triple> triples, Triple m) {
         return new LinkedDataFragment(triples, m);
     }
 
-    public static LinkedDataFragment create(TripleMatch m) {
+    public static LinkedDataFragment create(Triple m) {
         return new LinkedDataFragment(m);
     }
 
-    public static LinkedDataFragment create(TripleMatch m, Long matchCount) {
+    public static LinkedDataFragment create(Triple m, Long matchCount) {
         return new LinkedDataFragment(m, matchCount);
     }
 }

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraph.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraph.java
@@ -1,19 +1,19 @@
 package org.linkeddatafragments.model;
 
 import com.google.common.primitives.Ints;
-import com.hp.hpl.jena.graph.*;
-import com.hp.hpl.jena.graph.impl.GraphBase;
-import com.hp.hpl.jena.graph.impl.GraphMatcher;
-import com.hp.hpl.jena.query.ARQ;
-import com.hp.hpl.jena.shared.AddDeniedException;
-import com.hp.hpl.jena.shared.ClosedException;
-import com.hp.hpl.jena.shared.PrefixMapping;
-import com.hp.hpl.jena.sparql.engine.main.QC;
-import com.hp.hpl.jena.sparql.engine.optimizer.reorder.ReorderTransformation;
-import com.hp.hpl.jena.util.iterator.ClosableIterator;
-import com.hp.hpl.jena.util.iterator.ExtendedIterator;
-import com.hp.hpl.jena.util.iterator.WrappedIterator;
 
+import org.apache.jena.graph.*;
+import org.apache.jena.graph.impl.GraphBase;
+import org.apache.jena.graph.impl.GraphMatcher;
+import org.apache.jena.query.ARQ;
+import org.apache.jena.shared.AddDeniedException;
+import org.apache.jena.shared.ClosedException;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.sparql.engine.main.QC;
+import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation;
+import org.apache.jena.util.iterator.ClosableIterator;
+import org.apache.jena.util.iterator.ExtendedIterator;
+import org.apache.jena.util.iterator.WrappedIterator;
 import org.linkeddatafragments.client.LinkedDataFragmentsClient;
 import org.linkeddatafragments.solver.LDFStatistics;
 import org.linkeddatafragments.solver.LinkedDataFragmentEngine;
@@ -63,25 +63,25 @@ public class LinkedDataFragmentGraph extends GraphBase {
         return capabilities;
     }
 
-    @Override
-    protected ExtendedIterator<Triple> graphBaseFind(TripleMatch m) {
-        try{
-            LinkedDataFragment ldf = ldfClient.getFragment(ldfClient.getBaseFragment(), m);
-//            ExtendedIterator<Triple> triples = ldf.getTriples();
-//            Iterator<LinkedDataFragment> ldfIterator = LinkedDataFragmentIterator.create(ldf, ldfClient);
-//            while(ldfIterator.hasNext()) {
-//                ldf = ldfIterator.next();
-//                triples = triples.andThen(ldf.getTriples());
-//            }
-            ExtendedIterator<Triple> triples = ExtendedTripleIteratorLDF.create(ldfClient, ldf);
-            return triples;
-        } catch(Exception e) {
-            e.printStackTrace();
-            return WrappedIterator.emptyIterator(); //Do not block on error but return empty iterator
-        }
-    }
+//    @Override
+//    protected ExtendedIterator<Triple> graphBaseFind(Triple m) {
+//        try{
+//            LinkedDataFragment ldf = ldfClient.getFragment(ldfClient.getBaseFragment(), m);
+////            ExtendedIterator<Triple> triples = ldf.getTriples();
+////            Iterator<LinkedDataFragment> ldfIterator = LinkedDataFragmentIterator.create(ldf, ldfClient);
+////            while(ldfIterator.hasNext()) {
+////                ldf = ldfIterator.next();
+////                triples = triples.andThen(ldf.getTriples());
+////            }
+//            ExtendedIterator<Triple> triples = ExtendedTripleIteratorLDF.create(ldfClient, ldf);
+//            return triples;
+//        } catch(Exception e) {
+//            e.printStackTrace();
+//            return WrappedIterator.emptyIterator(); //Do not block on error but return empty iterator
+//        }
+//    }
 
-    public Long getCount(TripleMatch m) {
+    public Long getCount(Triple m) {
         //System.out.println("count requested");
         try{
             LinkedDataFragment ldf = ldfClient.getFragment(ldfClient.getBaseFragment(), m);

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraph.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraph.java
@@ -63,23 +63,23 @@ public class LinkedDataFragmentGraph extends GraphBase {
         return capabilities;
     }
 
-//    @Override
-//    protected ExtendedIterator<Triple> graphBaseFind(Triple m) {
-//        try{
-//            LinkedDataFragment ldf = ldfClient.getFragment(ldfClient.getBaseFragment(), m);
-////            ExtendedIterator<Triple> triples = ldf.getTriples();
-////            Iterator<LinkedDataFragment> ldfIterator = LinkedDataFragmentIterator.create(ldf, ldfClient);
-////            while(ldfIterator.hasNext()) {
-////                ldf = ldfIterator.next();
-////                triples = triples.andThen(ldf.getTriples());
-////            }
-//            ExtendedIterator<Triple> triples = ExtendedTripleIteratorLDF.create(ldfClient, ldf);
-//            return triples;
-//        } catch(Exception e) {
-//            e.printStackTrace();
-//            return WrappedIterator.emptyIterator(); //Do not block on error but return empty iterator
-//        }
-//    }
+    @Override
+    protected ExtendedIterator<Triple> graphBaseFind(Triple m) {
+        try{
+            LinkedDataFragment ldf = ldfClient.getFragment(ldfClient.getBaseFragment(), m);
+//            ExtendedIterator<Triple> triples = ldf.getTriples();
+//            Iterator<LinkedDataFragment> ldfIterator = LinkedDataFragmentIterator.create(ldf, ldfClient);
+//            while(ldfIterator.hasNext()) {
+//                ldf = ldfIterator.next();
+//                triples = triples.andThen(ldf.getTriples());
+//            }
+            ExtendedIterator<Triple> triples = ExtendedTripleIteratorLDF.create(ldfClient, ldf);
+            return triples;
+        } catch(Exception e) {
+            e.printStackTrace();
+            return WrappedIterator.emptyIterator(); //Do not block on error but return empty iterator
+        }
+    }
 
     public Long getCount(Triple m) {
         //System.out.println("count requested");
@@ -173,9 +173,9 @@ public class LinkedDataFragmentGraph extends GraphBase {
         return b.toString();
     }
 
-    @Override
-    protected ExtendedIterator<Triple> graphBaseFind(Triple triple) {
-        return find(triple);
-    }
+//    @Override
+//    protected ExtendedIterator<Triple> graphBaseFind(Triple triple) {
+//        return find(triple);
+//    }
 
 }

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraphCapabilities.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentGraphCapabilities.java
@@ -1,6 +1,7 @@
 package org.linkeddatafragments.model;
 
-import com.hp.hpl.jena.graph.Capabilities;
+
+import org.apache.jena.graph.Capabilities;
 
 public class LinkedDataFragmentGraphCapabilities implements Capabilities
 {

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentIterator.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentIterator.java
@@ -1,9 +1,8 @@
 package org.linkeddatafragments.model;
 
-import com.hp.hpl.jena.graph.TripleMatch;
-
 import java.util.Iterator;
 
+import org.apache.jena.graph.Triple;
 import org.linkeddatafragments.client.LinkedDataFragmentsClient;
 
 /**
@@ -11,7 +10,7 @@ import org.linkeddatafragments.client.LinkedDataFragmentsClient;
  */
 public class LinkedDataFragmentIterator implements Iterator<LinkedDataFragment> {
     protected final LinkedDataFragment baseFragment;
-    protected final TripleMatch tripleTemplate;
+    protected final Triple tripleTemplate;
     protected final LinkedDataFragmentsClient ldfClient;
 
     protected LinkedDataFragment currentFragment;

--- a/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentsConstants.java
+++ b/src/main/java/org/linkeddatafragments/model/LinkedDataFragmentsConstants.java
@@ -1,19 +1,20 @@
 package org.linkeddatafragments.model;
 
-import com.hp.hpl.jena.graph.Node;
-import com.hp.hpl.jena.graph.NodeFactory;
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.graph.TripleMatchFilter;
-import com.hp.hpl.jena.rdf.model.Property;
-import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.rdf.model.ResourceFactory;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+
 
 /**
  * Created by ldevocht on 4/29/14.
  */
 public class LinkedDataFragmentsConstants {
-    public static final TripleMatchFilter HYDRA_VARIABLE = new TripleMatchFilter(new Triple(Node.ANY, NodeFactory.createURI("http://www.w3.org/ns/hydra/core#variable"), Node.ANY));
-    public static final TripleMatchFilter HYDRA_PROPERTY = new TripleMatchFilter(new Triple(Node.ANY, NodeFactory.createURI("http://www.w3.org/ns/hydra/core#property"), Node.ANY));
+    public static final Triple HYDRA_VARIABLE = new Triple(Node.ANY, NodeFactory.createURI("http://www.w3.org/ns/hydra/core#variable"), Node.ANY);
+    public static final Triple HYDRA_PROPERTY = new Triple(Node.ANY, NodeFactory.createURI("http://www.w3.org/ns/hydra/core#property"), Node.ANY);
     public static final Property RDF_TYPE_RESOURCE = ResourceFactory.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
     public static final Resource VOID_DATASET_RESOURCE = ResourceFactory.createResource("http://rdfs.org/ns/void#Dataset");
     public static final Property HYDRA_NEXTPAGE = ResourceFactory.createProperty("http://www.w3.org/ns/hydra/core#nextPage");

--- a/src/main/java/org/linkeddatafragments/solver/BindingOne.java
+++ b/src/main/java/org/linkeddatafragments/solver/BindingOne.java
@@ -1,12 +1,12 @@
 package org.linkeddatafragments.solver;
 
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+
 import java.util.Iterator;
 
-import org.apache.jena.atlas.iterator.Iter;
-
-import com.hp.hpl.jena.graph.Node;
-import com.hp.hpl.jena.sparql.core.Var;
-import com.hp.hpl.jena.sparql.engine.binding.Binding;
 
 /**
  * Copied from Jena distribution because the constructor was protected

--- a/src/main/java/org/linkeddatafragments/solver/LDFStatistics.java
+++ b/src/main/java/org/linkeddatafragments/solver/LDFStatistics.java
@@ -1,10 +1,10 @@
 package org.linkeddatafragments.solver;
 
+import org.apache.jena.graph.GraphStatisticsHandler;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
 import org.linkeddatafragments.model.LinkedDataFragmentGraph;
 
-import com.hp.hpl.jena.graph.GraphStatisticsHandler;
-import com.hp.hpl.jena.graph.Node;
-import com.hp.hpl.jena.graph.Triple;
 
 /**
  * @author ldevocht

--- a/src/main/java/org/linkeddatafragments/solver/LinkedDataFragmentEngine.java
+++ b/src/main/java/org/linkeddatafragments/solver/LinkedDataFragmentEngine.java
@@ -1,18 +1,19 @@
 package org.linkeddatafragments.solver;
 
+import org.apache.jena.query.Query;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.engine.Plan;
+import org.apache.jena.sparql.engine.QueryEngineFactory;
+import org.apache.jena.sparql.engine.QueryEngineRegistry;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.main.QueryEngineMain;
+import org.apache.jena.sparql.util.Context;
+
 /**
  * Created by ldevocht on 4/28/14.
  */
-import com.hp.hpl.jena.query.Query;
-import com.hp.hpl.jena.sparql.ARQInternalErrorException;
-import com.hp.hpl.jena.sparql.algebra.Op;
-import com.hp.hpl.jena.sparql.core.DatasetGraph;
-import com.hp.hpl.jena.sparql.engine.Plan;
-import com.hp.hpl.jena.sparql.engine.QueryEngineFactory;
-import com.hp.hpl.jena.sparql.engine.QueryEngineRegistry;
-import com.hp.hpl.jena.sparql.engine.binding.Binding;
-import com.hp.hpl.jena.sparql.engine.main.QueryEngineMain;
-import com.hp.hpl.jena.sparql.util.Context;
 
 public class LinkedDataFragmentEngine extends QueryEngineMain {
 

--- a/src/main/java/org/linkeddatafragments/solver/OpExecutorLDF.java
+++ b/src/main/java/org/linkeddatafragments/solver/OpExecutorLDF.java
@@ -1,25 +1,24 @@
 package org.linkeddatafragments.solver;
 
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.op.OpBGP;
+import org.apache.jena.sparql.algebra.op.OpDistinct;
+import org.apache.jena.sparql.algebra.op.OpFilter;
+import org.apache.jena.sparql.algebra.op.OpReduced;
+import org.apache.jena.sparql.algebra.optimize.TransformFilterPlacement;
+import org.apache.jena.sparql.core.BasicPattern;
+import org.apache.jena.sparql.core.Substitute;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.iterator.QueryIterPeek;
+import org.apache.jena.sparql.engine.main.OpExecutor;
+import org.apache.jena.sparql.engine.main.OpExecutorFactory;
+import org.apache.jena.sparql.engine.main.QC;
+import org.apache.jena.sparql.engine.optimizer.reorder.ReorderProc;
+import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation;
+import org.apache.jena.sparql.expr.ExprList;
 import org.linkeddatafragments.model.LinkedDataFragmentGraph;
-
-import com.hp.hpl.jena.sparql.ARQInternalErrorException;
-import com.hp.hpl.jena.sparql.algebra.Op;
-import com.hp.hpl.jena.sparql.algebra.op.OpBGP;
-import com.hp.hpl.jena.sparql.algebra.op.OpDistinct;
-import com.hp.hpl.jena.sparql.algebra.op.OpFilter;
-import com.hp.hpl.jena.sparql.algebra.op.OpReduced;
-import com.hp.hpl.jena.sparql.algebra.optimize.TransformFilterPlacement;
-import com.hp.hpl.jena.sparql.core.BasicPattern;
-import com.hp.hpl.jena.sparql.core.Substitute;
-import com.hp.hpl.jena.sparql.engine.ExecutionContext;
-import com.hp.hpl.jena.sparql.engine.QueryIterator;
-import com.hp.hpl.jena.sparql.engine.iterator.QueryIterPeek;
-import com.hp.hpl.jena.sparql.engine.main.OpExecutor;
-import com.hp.hpl.jena.sparql.engine.main.OpExecutorFactory;
-import com.hp.hpl.jena.sparql.engine.main.QC;
-import com.hp.hpl.jena.sparql.engine.optimizer.reorder.ReorderProc;
-import com.hp.hpl.jena.sparql.engine.optimizer.reorder.ReorderTransformation;
-import com.hp.hpl.jena.sparql.expr.ExprList;
 
 public class OpExecutorLDF extends OpExecutor {
 

--- a/src/main/java/org/linkeddatafragments/solver/ReorderTransformationLDF.java
+++ b/src/main/java/org/linkeddatafragments/solver/ReorderTransformationLDF.java
@@ -1,18 +1,18 @@
 package org.linkeddatafragments.solver;
 
+import org.apache.jena.graph.GraphStatisticsHandler;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.engine.optimizer.Pattern;
+import org.apache.jena.sparql.engine.optimizer.StatsMatcher;
+import org.apache.jena.sparql.engine.optimizer.reorder.PatternTriple;
+import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformationSubstitution;
+import org.apache.jena.sparql.graph.NodeConst;
+import org.apache.jena.sparql.sse.Item;
 import org.linkeddatafragments.model.LinkedDataFragmentGraph;
 
-import com.hp.hpl.jena.graph.GraphStatisticsHandler;
-import com.hp.hpl.jena.graph.Node;
-import com.hp.hpl.jena.sparql.engine.optimizer.Pattern;
-import com.hp.hpl.jena.sparql.engine.optimizer.StatsMatcher;
-import com.hp.hpl.jena.sparql.engine.optimizer.reorder.PatternTriple;
-import com.hp.hpl.jena.sparql.engine.optimizer.reorder.ReorderTransformationSubstitution;
-import com.hp.hpl.jena.sparql.graph.NodeConst;
-import com.hp.hpl.jena.sparql.sse.Item;
+import static org.apache.jena.sparql.engine.optimizer.reorder.PatternElements.TERM;
+import static org.apache.jena.sparql.engine.optimizer.reorder.PatternElements.VAR;
 
-import static com.hp.hpl.jena.sparql.engine.optimizer.reorder.PatternElements.TERM;
-import static com.hp.hpl.jena.sparql.engine.optimizer.reorder.PatternElements.VAR;
 
 /**
  * Reorders the Triple Patterns of a BGP by using statistics directly fetched from

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout>
+                <Pattern>%d %p [%t] %C(%L): %m%n</Pattern>
+            </PatternLayout>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <!-- our own code -->
+        <logger name="org.linkeddatafragments" level="debug" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </logger>
+
+        <!-- Anything else -->
+        <Root level="warn">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+
+</Configuration>

--- a/src/test/java/org/linkeddatafragments/LinkedDataFragmentsClientTest.java
+++ b/src/test/java/org/linkeddatafragments/LinkedDataFragmentsClientTest.java
@@ -21,13 +21,13 @@ public class LinkedDataFragmentsClientTest {
 
     @Before
     public void setUp() {
-        LinkedDataFragmentGraph ldfg = new LinkedDataFragmentGraph("http://data.linkeddatafragments.org/dbpedia");
+        LinkedDataFragmentGraph ldfg = new LinkedDataFragmentGraph("http://data.linkeddatafragments.org/dbpedia2014");
         model = ModelFactory.createModelForGraph(ldfg);
     }
 
     @Test
     public void testSize() {
-        assertThat(model.size()).isEqualTo(427670470);
+        assertThat(model.size()).isEqualTo(377367913);
         System.out.println(model.size());
     }
 
@@ -53,7 +53,7 @@ public class LinkedDataFragmentsClientTest {
         while(rs.hasNext()) {
             System.out.println(rs.nextSolution().toString());
         }
-
+        System.out.println("rs.getRowNumber() = " + rs.getRowNumber());
         assertThat(rs.getRowNumber()).isGreaterThan(0);
     }
 

--- a/src/test/java/org/linkeddatafragments/LinkedDataFragmentsClientTest.java
+++ b/src/test/java/org/linkeddatafragments/LinkedDataFragmentsClientTest.java
@@ -1,11 +1,11 @@
 package org.linkeddatafragments;
 
 import com.google.common.base.Stopwatch;
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.query.*;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
 
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.linkeddatafragments.model.LinkedDataFragmentGraph;
@@ -161,7 +161,7 @@ public class LinkedDataFragmentsClientTest {
                 assertThat(rm.hasNext()).isTrue();
 
                 while(rm.hasNext()) {
-                    System.out.println(rm.next().asTriple().toString());
+                    System.out.println(rm.next().toString());
                 }
 
             } else if(qe.getQuery().getQueryType() == Query.QueryTypeSelect) {


### PR DESCRIPTION
Update to Java 8, Jena 3.1.0 (which requires Java >= 8), other libraries updated as well. Tried to change the code as little as possible. This could be a basis for further development.

Cheers,
Gerald
